### PR TITLE
chore(deps): bump crypto-js and @types/crypto-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@mui/icons-material": "^5.14.9",
         "@mui/material": "^5.14.10",
         "copy-text-to-clipboard": "^3.2.0",
-        "crypto-js": "^4.1.1",
+        "crypto-js": "^4.2.0",
         "lottie-react": "^2.4.0",
         "nanoid": "^5.0.1",
         "otpauth": "^9.1.4",
@@ -26,7 +26,7 @@
       },
       "devDependencies": {
         "@twa-dev/types": "github:UselessStudio/twa-types",
-        "@types/crypto-js": "^4.1.2",
+        "@types/crypto-js": "^4.2.2",
         "@types/node": "^20.12.2",
         "@types/react": "^18.2.73",
         "@types/react-dom": "^18.2.23",
@@ -2001,9 +2001,9 @@
       }
     },
     "node_modules/@types/crypto-js": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.1.2.tgz",
-      "integrity": "sha512-t33RNmTu5ufG/sorROIafiCVJMx3jz95bXUMoPAZcUD14fxMXnuTzqzXZoxpR0tNx2xpw11Dlmem9vGCsrSOfA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.2.2.tgz",
+      "integrity": "sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ==",
       "dev": true
     },
     "node_modules/@types/estree": {
@@ -2807,9 +2807,9 @@
       }
     },
     "node_modules/crypto-js": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
-      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "node_modules/csstype": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@mui/icons-material": "^5.14.9",
     "@mui/material": "^5.14.10",
     "copy-text-to-clipboard": "^3.2.0",
-    "crypto-js": "^4.1.1",
+    "crypto-js": "^4.2.0",
     "lottie-react": "^2.4.0",
     "nanoid": "^5.0.1",
     "otpauth": "^9.1.4",
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@twa-dev/types": "github:UselessStudio/twa-types",
-    "@types/crypto-js": "^4.1.2",
+    "@types/crypto-js": "^4.2.2",
     "@types/node": "^20.12.2",
     "@types/react": "^18.2.73",
     "@types/react-dom": "^18.2.23",


### PR DESCRIPTION
Bumps [crypto-js](https://github.com/brix/crypto-js) and [@types/crypto-js](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/HEAD/types/crypto-js). These dependencies needed to be updated together.

Updates `crypto-js` from 4.1.1 to 4.2.0
- [Commits](https://github.com/brix/crypto-js/compare/4.1.1...4.2.0)

Updates `@types/crypto-js` from 4.1.2 to 4.2.2
- [Release notes](https://github.com/DefinitelyTyped/DefinitelyTyped/releases)
- [Commits](https://github.com/DefinitelyTyped/DefinitelyTyped/commits/HEAD/types/crypto-js)

---
updated-dependencies:
- dependency-name: crypto-js dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: "@types/crypto-js" dependency-type: direct:development update-type: version-update:semver-minor ...